### PR TITLE
logical bug fix

### DIFF
--- a/GlobalEventEmitter.ios.js
+++ b/GlobalEventEmitter.ios.js
@@ -49,9 +49,6 @@ function removeListener(eventName, callbackRef) {
 function removeAllListeners(eventName) {
   RNTGlobalEventEmitter.removeObserver(eventName);
   delete listeners[eventName];
-  if (!listeners.length) {
-      DeviceEventEmitter.removeAllListeners('onNotification');
-  };
 }
 
 var DeviceMotion = {


### PR DESCRIPTION
If there is no event handler in js, it will directly remove the global listener "onNotification" from NSNotificationCenter, which makes the program cannot listen to any events later. Delete these code will fix that.
