### PR TITLE
Optimizations and bug fix

### DIFF
--- a/GlobalEventEmitter.ios.js
+++ b/GlobalEventEmitter.ios.js
@@ -12,7 +12,6 @@ var listeners = {};
 DeviceEventEmitter.addListener('onNotification', (data) => {
   var notifName = data.name;
   var notifData = data.userInfo;
-
   for (var i=0; i<listeners[notifName].length; i++) {
     var listener = listeners[notifName][i];
     listener(notifData);
@@ -20,15 +19,14 @@ DeviceEventEmitter.addListener('onNotification', (data) => {
 });
 
 function addListener(eventName, callback) {
-  var callBacks = [];
   if (listeners[eventName]) {
-    callBacks = listeners[eventName];
+    listeners[eventName].push(callback);
   }
-
-  callBacks.push(callback);
-
-  listeners[eventName] = callBacks;
-  RNTGlobalEventEmitter.addObserver(eventName);
+  else {
+    listeners[eventName] = [callback];
+    RNTGlobalEventEmitter.addObserver(eventName);
+  }
+  return listeners[eventName].indexOf(callback);
 };
 
 function emit(eventName, data) {
@@ -46,12 +44,13 @@ function removeListener(eventName, callbackRef) {
   };
 }
 
+function removeListenderById(eventName, Id) {
+  listeners[eventName].splice(Id, 1);
+}
+
 function removeAllListeners(eventName) {
   RNTGlobalEventEmitter.removeObserver(eventName);
   delete listeners[eventName];
-  if (!listeners.length) {
-      DeviceEventEmitter.removeAllListeners('onNotification');
-  };
 }
 
 var DeviceMotion = {
@@ -59,6 +58,7 @@ var DeviceMotion = {
   emit,
   removeListener,
   removeAllListeners,
+  removeListenderById
 };
 
 DeviceMotion.UIApplicationNotifications = RNTGlobalEventEmitter.UIApplicationNotifications;


### PR DESCRIPTION
Hi there,
I noticed that inside the `addListener`, if someone trying to listen to an event which is already listened before, which will cause `RNTGlobalEventEmitter.addObserver(eventName);` run one more time, which is unnecessary to register an native listener at NSNotificationCenter.

Whats more, I added `removeListenderById` method, because sometimes to deal with scope issues, you need to passing a closure / code block to the `addListener`, which makes `removeListener` harder. With `removeListenderById`, you only need to passing the event name and the reference ID, which can get from `addListener`.
